### PR TITLE
Use function instead of just checking git dir

### DIFF
--- a/fish_right_prompt.fish
+++ b/fish_right_prompt.fish
@@ -33,7 +33,7 @@ function fish_right_prompt
     | sed "s|$base|"(hulk::trd)" $base"(off)"|g"
   end
 
-  if test -d .git
+  if git_is_repo
     echo (hulk::status::color)" ≡ "(hulk::snd)(begin
       git_is_touched; and hulk::branch_name; or echo (hulk::dim)(hulk::branch_name)
     end)(off)


### PR DESCRIPTION
If we're not in the root of the repo, we still want the branch name to be printed.

The function has logic to make sure this happens, whereas just checking for the presence of `.git` doesn't.
